### PR TITLE
[FIX] Show all questions if searchFilter is empty

### DIFF
--- a/Resources/Public/Javascript/jpFaq.js
+++ b/Resources/Public/Javascript/jpFaq.js
@@ -155,7 +155,7 @@ var jpFaq = jpFaq || {};
                     // Hiding element if there's no match and search field not empty
                     if (!isMatch && words.length > 0){
                         $(this).fadeOut('fast');
-                    }else if(isMatch){
+                    }else{
                         $(this).show();
                     }
                 });


### PR DESCRIPTION
I noticed that when erasing the search field by holding the backspace-key, the state of shown/hidden questions didn't change. The expected behaviour upon emptying the search field is that all questions are shown (like on page entry).

It's because the else-condition checks if isMatch is true. In this case its false because there can be no match with an empty searchFilter.

It seems to work in practice, but I guess @VladVilya knows the code more intimately. :)